### PR TITLE
Change Faraday request to FastImage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,9 @@ gem 'unicorn'
 gem 'figaro'
 gem 'simplecov', :require => false, :group => :test
 gem 'faraday'
-gem 'faraday_middleware'
 gem 'responders', '~> 2.0'
 gem "selenium-webdriver"
+gem 'fastimage'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,8 +78,8 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
+    fastimage (2.0.0)
+      addressable (~> 2)
     ffi (1.9.10)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -242,7 +242,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl_rails
   faraday
-  faraday_middleware
+  fastimage
   figaro
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/services/trelora_services.rb
+++ b/app/services/trelora_services.rb
@@ -40,14 +40,12 @@ class TreloraServices
         elsif result[:best_large_image] == nil
           false
         else
-          prefix = result[:best_large_image].split("/")[0..2].join("/")
-          final  = "/" + result[:best_large_image].split("/")[3..-1].join("/").gsub(" ", "%20")
-          image = Faraday.new(prefix) { |b|
-            b.use FaradayMiddleware::FollowRedirects
-            b.adapter :net_http
-          }
-          status = image.head(final).status
-          status < 400
+          dimensions = FastImage.size(result[:best_large_image])
+          if dimensions == nil || dimensions[0] < dimensions[1]
+            false
+          else
+            true
+          end
         end
       end
     end

--- a/spec/services/trelora_services_spec.rb
+++ b/spec/services/trelora_services_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe TreloraServices do
       trelora      = service.house_listing('comingsoon')
       first_result = trelora.first
 
-      expect(trelora.count).to eq(21)
+      expect(trelora.count).to eq(17)
       expect(first_result[:role]).to eq("Coming Soon")
       expect(first_result[:ribbon]).to eq("Coming Soon!")
       expect(first_result[:ribbon_color]).to eq("#99cc77")


### PR DESCRIPTION
FastImage captures dimensions, and returns nil if no image exists. Having dimensions allows us to filter for images in portrait. Additionally, code appears to more directly check for image characteristics, making the request/filtering process easier to understand on review.

@Salvi6God Let's discuss.
