### PR TITLE
Add local storage of slides

### DIFF
--- a/app/controllers/admin/slides_controller.rb
+++ b/app/controllers/admin/slides_controller.rb
@@ -1,0 +1,6 @@
+class Admin::SlidesController < ApplicationController
+  def update
+    Slide.update_slides
+    redirect_to admin_devices_path
+  end
+end

--- a/app/controllers/api/v1/signage_controller.rb
+++ b/app/controllers/api/v1/signage_controller.rb
@@ -4,7 +4,7 @@ module Api
       respond_to :json
 
       def index
-        response = {time: time, signs: signs}
+        response = {time: time, signs: JSON.parse(signs)}
         respond_with JSON.generate(response)
       end
 
@@ -14,11 +14,8 @@ module Api
         end
 
         def signs
-          service = TreloraServices.new
-
           role = Device.find_by(device_code: cookies[:device_code]).role
-
-          service.house_listing(role)
+          Slide.where(api_role: role).to_json
         end
     end
   end

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -1,0 +1,47 @@
+class Slide < ActiveRecord::Base
+  def self.update_slides
+    delete_slides
+    slides = fetch_slides
+    insert_slides(slides)
+  end
+
+  private
+    def self.delete_slides
+      Slide.delete_all
+    end
+
+    def self.fetch_slides
+      roles = fetch_roles
+      roles.map do |role|
+        TreloraServices.new.house_listing(role)
+      end.flatten
+    end
+
+    def self.fetch_roles
+      TreloraServices.new.get_roles
+    end
+
+    def self.translate_roles
+      roles = fetch_roles
+
+      roles.reduce({}) do |translations, role|
+        key = TreloraServices.new.house_listing(role.to_sym).first[:role]
+        translations[key] = role
+        translations
+      end
+    end
+
+    def self.insert_slides(slides)
+      translation = translate_roles
+      slides.each do |slide|
+        Slide.create(role: slide[:role],
+                     api_role: translation[slide[:role]],
+                     ribbon: slide[:ribbon],
+                     ribbon_color: slide[:ribbon_color],
+                     title: slide[:title],
+                     subtitle: slide[:subtitle],
+                     best_large_image: slide[:best_large_image]
+        )
+      end
+    end
+end

--- a/app/views/admin/devices/index.html.erb
+++ b/app/views/admin/devices/index.html.erb
@@ -6,6 +6,12 @@
   <h1 class="text-center" id="titles">Devices</h1>
 
   <p id="timer">
+    Refresh: Use button below to refresh the slides from the Trelora Signage API.
+  </p>
+
+  <%= link_to "Refresh Slides", admin_refresh_slides_path %>
+
+  <p id="timer">
     <i class="fa fa-clock-o" aria-hidden="true"></i>  Current Slide Time: <%= @devices.time %> second(s) per slide
   </p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
+    get '/update_slides', to: "slides#update", as: :refresh_slides
     resources :devices, only: [:index, :edit, :update, :destroy]
     resources :display, only: [:update]
   end

--- a/db/migrate/20160613195051_create_slides.rb
+++ b/db/migrate/20160613195051_create_slides.rb
@@ -1,0 +1,14 @@
+class CreateSlides < ActiveRecord::Migration
+  def change
+    create_table :slides do |t|
+      t.string :role
+      t.string :ribbon
+      t.string :ribbon_color
+      t.string :title
+      t.string :subtitle
+      t.string :best_large_image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160613204757_add_api_role_to_slides.rb
+++ b/db/migrate/20160613204757_add_api_role_to_slides.rb
@@ -1,0 +1,5 @@
+class AddApiRoleToSlides < ActiveRecord::Migration
+  def change
+    add_column :slides, :api_role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160611191235) do
+ActiveRecord::Schema.define(version: 20160613204757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,18 @@ ActiveRecord::Schema.define(version: 20160611191235) do
 
   create_table "displays", force: :cascade do |t|
     t.integer "time"
+  end
+
+  create_table "slides", force: :cascade do |t|
+    t.string   "role"
+    t.string   "ribbon"
+    t.string   "ribbon_color"
+    t.string   "title"
+    t.string   "subtitle"
+    t.string   "best_large_image"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "api_role"
   end
 
 end

--- a/spec/features/admin/admin_can_update_slides_spec.rb
+++ b/spec/features/admin/admin_can_update_slides_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe "When an admin clicks on refresh" do
+  it "the slides are updated" do
+    VCR.use_cassette "admin_updates_slides" do
+      visit "/admin/devices"
+
+      click_on "Refresh Slides"
+
+      most_recent_update = Slide.maximum(:updated_at).strftime("%Y-%m-%d")
+      today = Time.new.strftime("%Y-%m-%d")
+      expect(most_recent_update).to eq(today)
+    end
+  end
+end

--- a/spec/requests/api/v1/signage_spec.rb
+++ b/spec/requests/api/v1/signage_spec.rb
@@ -3,12 +3,15 @@ require "rails_helper"
 RSpec.describe "GET /api/v1/signage" do
   it "returns an array of signage hashes" do
     VCR.use_cassette "internal_api" do
+      Slide.update_slides
+
       get '/'
       device = Device.last
       device.update(role: "comingsoon")
 
       get "/api/v1/signage"
 
+      # binding.pry
       expect(json_body["time"]).to eq(1000)
       expect(json_body["signs"].first["best_large_image"]).to eq("https://trelora.smugmug.com/1499-Blake-St-Unit-3L/i-pmXPcMm/0/X2/IS1fovc14evo0k0000000000-X2.jpg")
       expect(json_body["signs"].first["ribbon"]).to eq("Coming Soon!")

--- a/spec/services/trelora_services_spec.rb
+++ b/spec/services/trelora_services_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe TreloraServices do
       trelora      = service.house_listing('comingsoon')
       first_result = trelora.first
 
-      expect(trelora.count).to eq(17)
+      expect(trelora.count).to eq(19)
       expect(first_result[:role]).to eq("Coming Soon")
       expect(first_result[:ribbon]).to eq("Coming Soon!")
       expect(first_result[:ribbon_color]).to eq("#99cc77")


### PR DESCRIPTION
Add slide table to make slides render more quickly.
- Created slide model, controller, test, migrations.
- Switched API Signage controller to hit the new Slides table, instead of TreloraService.
- Added refresh button to admin panel so that slides can be updated when admin wishes.
