### PR TITLE
Add role update to slide update

### DIFF
--- a/app/assets/javascripts/device.js.erb
+++ b/app/assets/javascripts/device.js.erb
@@ -14,7 +14,7 @@ var pullSlides = function() {
 var renderContent = function(listingInfo){
   var deviceCode = $("#device-content").attr('class');
   if($.isEmptyObject(listingInfo.signs)){
-    $("#device-content").html("<h1>Screen ID: " + deviceCode + "</h1>");
+    $("#device-content").html("<h1 id='device-code'>Screen ID: " + deviceCode + "</h1>");
     window.setTimeout(function(){pullSlides();}, 10000);
   } else {
     renderSign(0, listingInfo, renderSign);

--- a/app/assets/stylesheets/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin_dashboard.scss
@@ -31,11 +31,27 @@ body {
   margin-bottom: 10px;
 }
 
+#refresh {
+  font-size: 30px;
+  font-weight: lighter;
+  margin-bottom: 10px;
+}
+
 .font-format {
   font-size: 30px;
   margin-top: 10px;
   font-weight: lighter;
   letter-spacing: 5px;
+}
+
+#button-refresh {
+  margin-top: 20px;
+  background-color: #96C93D;
+  -moz-border-radius: 4px;
+  -webkit-border-radius: 4px;
+  border-radius: 4px;
+  color: #fff;
+  margin-bottom: 20px;
 }
 
 #button-submit {

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -9,6 +9,10 @@ body {
   background-position: center;
 }
 
+#device-code {
+  color: black;
+}
+
 .ribbon {
   text-align: center;
   font-size: 3.85em;

--- a/app/controllers/admin/slides_controller.rb
+++ b/app/controllers/admin/slides_controller.rb
@@ -1,6 +1,7 @@
 class Admin::SlidesController < ApplicationController
   def update
     Slide.update_slides
+    Role.update_roles
     redirect_to admin_devices_path
   end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -8,9 +8,4 @@ class Device < ActiveRecord::Base
     end
     device_code
   end
-
-  def self.roles
-    service = TreloraServices.new
-    service.get_roles
-  end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,26 @@
+class Role < ActiveRecord::Base
+  def self.update_roles
+    delete_roles
+    roles = fetch_roles
+    insert_roles(roles)
+  end
+
+  def self.all_roles
+    Role.all.pluck(:role)
+  end
+
+  private
+    def self.delete_roles
+      Role.delete_all
+    end
+
+    def self.fetch_roles
+      TreloraServices.new.get_roles
+    end
+
+    def self.insert_roles(roles)
+      roles.each do |role|
+        Role.create(role: role)
+      end
+    end
+end

--- a/app/views/admin/devices/edit.html.erb
+++ b/app/views/admin/devices/edit.html.erb
@@ -13,7 +13,7 @@
 
       <%= f.label :role, class: 'font-format' %>
       <div class="form-group">
-        <%= f.select(:role, options_for_select(Device.roles), {}, {class: "form-control"}) %>
+        <%= f.select(:role, options_for_select(Role.all_roles), {}, {class: "form-control"}) %>
       </div>
 
       <div class="form-group ">

--- a/app/views/admin/devices/index.html.erb
+++ b/app/views/admin/devices/index.html.erb
@@ -5,11 +5,13 @@
 
   <h1 class="text-center" id="titles">Devices</h1>
 
-  <p id="timer">
-    Refresh: Use button below to refresh the slides from the Trelora Signage API.
+  <p id="refresh">
+    Refresh: Use button below to refresh or setup the slides and roles from the Trelora Signage API.
   </p>
 
-  <%= link_to "Refresh Slides", admin_refresh_slides_path %>
+  <div class="text-center">
+    <%= button_to "Refresh", admin_refresh_slides_path, class: 'font-format', id: "button-refresh", method: :get %>
+  </div>
 
   <p id="timer">
     <i class="fa fa-clock-o" aria-hidden="true"></i>  Current Slide Time: <%= @devices.time %> second(s) per slide

--- a/db/migrate/20160614195531_create_roles.rb
+++ b/db/migrate/20160614195531_create_roles.rb
@@ -1,0 +1,9 @@
+class CreateRoles < ActiveRecord::Migration
+  def change
+    create_table :roles do |t|
+      t.string :role
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160613204757) do
+ActiveRecord::Schema.define(version: 20160614195531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,12 @@ ActiveRecord::Schema.define(version: 20160613204757) do
 
   create_table "displays", force: :cascade do |t|
     t.integer "time"
+  end
+
+  create_table "roles", force: :cascade do |t|
+    t.string   "role"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "slides", force: :cascade do |t|

--- a/spec/features/admin/admin_can_edit_a_device_spec.rb
+++ b/spec/features/admin/admin_can_edit_a_device_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe "When an admin clicks on a device" do
 
     expect(current_path).to eq("/admin/devices")
     expect(page).to have_content("Meeting Room 1")
-end
+  end
 
   it "they are able to give the device a role" do
+    Role.update_roles
     device = create(:device)
 
     visit '/admin/devices'

--- a/spec/features/admin/admin_can_update_slides_spec.rb
+++ b/spec/features/admin/admin_can_update_slides_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe "When an admin clicks on refresh" do
     VCR.use_cassette "admin_updates_slides" do
       visit "/admin/devices"
 
-      click_on "Refresh Slides"
+      click_on "Refresh"
 
-      most_recent_update = Slide.maximum(:updated_at).strftime("%Y-%m-%d")
+      most_recent_slides = Slide.maximum(:updated_at).strftime("%Y-%m-%d")
+      most_recent_roles = Role.maximum(:updated_at).strftime("%Y-%m-%d")
       today = Time.new.strftime("%Y-%m-%d")
-      expect(most_recent_update).to eq(today)
+      expect(most_recent_slides).to eq(today)
+      expect(most_recent_roles).to eq(today)
     end
   end
 end

--- a/spec/services/trelora_services_spec.rb
+++ b/spec/services/trelora_services_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe TreloraServices do
       trelora      = service.house_listing('comingsoon')
       first_result = trelora.first
 
-      expect(trelora.count).to eq(19)
+      expect(trelora.count).to eq(18)
       expect(first_result[:role]).to eq("Coming Soon")
       expect(first_result[:ribbon]).to eq("Coming Soon!")
       expect(first_result[:ribbon_color]).to eq("#99cc77")


### PR DESCRIPTION
Adjust slide update button to also pull roles from Trelora API.
- Created a Role model
- Made admin update pull from role table
- Adjusted tests to reflect updated schema/approach/trelora API info.

Additional styling for admin device index, admin device update, and device code on slide page.
